### PR TITLE
修复不能增加多个Parameter的bug

### DIFF
--- a/ofdrw-core/src/main/java/org/ofdrw/core/annotation/pageannot/Annot.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/annotation/pageannot/Annot.java
@@ -376,6 +376,7 @@ public class Annot extends OFDElement {
             return this;
         }
 
+
         Element parameters = this.getOFDElement("Parameters");
         if (parameters == null) {
             parameters = OFDElement.getInstance("Parameters");

--- a/ofdrw-core/src/main/java/org/ofdrw/core/annotation/pageannot/Annot.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/annotation/pageannot/Annot.java
@@ -10,6 +10,7 @@ import org.ofdrw.core.basicType.ST_ID;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -374,14 +375,27 @@ public class Annot extends OFDElement {
         if (name == null || name.trim().length() == 0) {
             return this;
         }
+
         Element parameters = this.getOFDElement("Parameters");
         if (parameters == null) {
             parameters = OFDElement.getInstance("Parameters");
+            this.add(parameters);
         }
-        OFDElement parameterEl = new OFDSimpleTypeElement("Parameter", parameter);
-        parameterEl.addAttribute("Name", name);
-        parameters.add(parameterEl);
-        this.add(parameters);
+        Iterator<Element> iterator = parameters.elementIterator();
+        Boolean foundKey = false;
+        while (iterator.hasNext()) {
+            Element element = iterator.next();
+            if (element.attribute("Name").getValue().equalsIgnoreCase(name)) {
+                element.setText(parameter);
+                foundKey = true;
+                break;
+            }
+        }
+        if (!foundKey) {
+            OFDElement parameterEl = new OFDSimpleTypeElement("Parameter", parameter);
+            parameterEl.addAttribute("Name", name);
+            parameters.add(parameterEl);
+        }
         return this;
     }
 

--- a/ofdrw-core/src/main/java/org/ofdrw/core/annotation/pageannot/Annot.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/annotation/pageannot/Annot.java
@@ -376,7 +376,6 @@ public class Annot extends OFDElement {
             return this;
         }
 
-
         Element parameters = this.getOFDElement("Parameters");
         if (parameters == null) {
             parameters = OFDElement.getInstance("Parameters");

--- a/ofdrw-core/src/test/java/org/ofdrw/core/annotation/pageannot/AnnotTest.java
+++ b/ofdrw-core/src/test/java/org/ofdrw/core/annotation/pageannot/AnnotTest.java
@@ -23,6 +23,8 @@ public class AnnotTest {
                 .setLastModDate(LocalDate.now())
                 .setRemark("这是一段说明内容")
                 .addParameter("Key", "Value")
+                .addParameter("Key", "Value2")
+                .addParameter("Key2", "Value3")
                 .setAppearance(appearance);
     }
     @Test


### PR DESCRIPTION
1.修改了在Annot中不能增加多个Parameter的错误
2.如果Parameter的Name有重复，则覆盖旧Value，保证Parameter的Name是唯一