### PR TITLE
解决文档有MaxSignId节点时，重复添加该节点，导致再次签署最大ID错误问题

### DIFF
--- a/ofdrw-core/src/main/java/org/ofdrw/core/signatures/Signatures.java
+++ b/ofdrw-core/src/main/java/org/ofdrw/core/signatures/Signatures.java
@@ -42,10 +42,10 @@ public class Signatures extends OFDElement {
      * @return this
      */
     public Signatures setMaxSignId(String maxSignId) {
-        if (maxSignId == null) {
-            this.removeOFDElemByNames("MaxSignId");
+        this.removeOFDElemByNames("MaxSignId");
+        if (maxSignId != null) {
+            this.addOFDEntity("MaxSignId", maxSignId);
         }
-        this.addOFDEntity("MaxSignId", maxSignId);
         return this;
     }
 


### PR DESCRIPTION
解决文档有MaxSignId节点时，重复添加该节点，导致再次签署最大ID错误问题